### PR TITLE
Add missing umbrella header

### DIFF
--- a/iOS/L360Confetti/L360Confetti.h
+++ b/iOS/L360Confetti/L360Confetti.h
@@ -1,0 +1,15 @@
+//
+//  L360Confetti.h
+//  L360ConfettiExample
+//
+//  Created by Joshua Archer on 2/27/18.
+//  Copyright © 2018 Life360. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+#import <L360Confetti/L360ConfettiAble.h>
+#import <L360Confetti/L360ConfettiArea.h>
+#import <L360Confetti/L360ConfettiObject.h>
+#import <L360Confetti/L360ConfettiView.h>


### PR DESCRIPTION
- Umbrella header is important for tools like buck
- It's also the default header used in auto-generated header maps